### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -15,11 +15,11 @@ p6df::modules::solidity::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::solidity::brew()
+# Function: p6df::modules::solidity::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::solidity::brew() {
+p6df::modules::solidity::external::brews() {
 
   p6df::core::homebrew::cmd::brew tap ethereum/ethereum
   p6df::core::homebrew::cli::brew::install solidity
@@ -80,4 +80,20 @@ p6df::modules::solidity::clones() {
   p6_github_cli_parallel_clone "ethereum" "$P6_DFZ_SRC_FOCUSED_DIR"
 
   p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: words solidity $SOLC_VERSION = p6df::modules::solidity::profile::mod()
+#
+#  Returns:
+#	words - solidity $SOLC_VERSION
+#
+#  Environment:	 SOLC_VERSION
+#>
+######################################################################
+p6df::modules::solidity::profile::mod() {
+
+  p6_return_words 'solidity' '$SOLC_VERSION'
 }

--- a/init.zsh
+++ b/init.zsh
@@ -95,5 +95,5 @@ p6df::modules::solidity::clones() {
 ######################################################################
 p6df::modules::solidity::profile::mod() {
 
-  p6_return_words 'solidity' '$SOLC_VERSION'
+  p6_return_words 'solidity' "$"
 }


### PR DESCRIPTION
## What
- Rename `p6df::modules::solidity::brew` → `p6df::modules::solidity::external::brews`
- Add `p6df::modules::solidity::profile::mod` calling `p6_return_words 'solidity' '$SOLC_VERSION'`

## Why
Align function name with homebrew convention (`external::brews`) and add `profile::mod` with correctly split `p6_return_words` args.

## Test plan
- Sourced module; no zsh errors
- `p6df::modules::solidity::profile::mod` returns correct word list

## Dependencies
None