### PR TITLE
fix(prompt): set SOLC_VERSION env var in profile::mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ TODO: Add a short summary of this module.
 - `p6df::modules::solidity::clones()`
 - `p6df::modules::solidity::deps()`
 - `p6df::modules::solidity::langs()`
+- `words solidity $SOLC_VERSION = p6df::modules::solidity::profile::mod()`
 - `p6df::modules::solidity::vscodes()`
 
 ## Hierarchy

--- a/init.zsh
+++ b/init.zsh
@@ -95,5 +95,5 @@ p6df::modules::solidity::clones() {
 ######################################################################
 p6df::modules::solidity::profile::mod() {
 
-  p6_return_words 'solidity' "$"
+  p6_return_words 'solidity' '$SOLC_VERSION'
 }


### PR DESCRIPTION
## What
Replace placeholder `"$"` with `'$SOLC_VERSION'` in `p6df::modules::solidity::profile::mod()` and update README.

## Why
The prompt word list was missing the actual environment variable, causing the prompt to display nothing useful.

## Test plan
- Inspected change manually

## Dependencies
None