### PR TITLE
refactor(solidity): rename brew to brews and update profile::mod return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ TODO: Add a short summary of this module.
 
 ##### p6df-solidity/init.zsh
 
-- `p6df::modules::solidity::brew()`
 - `p6df::modules::solidity::clones()`
 - `p6df::modules::solidity::deps()`
+- `p6df::modules::solidity::external::brews()`
 - `p6df::modules::solidity::langs()`
-- `words solidity $SOLC_VERSION = p6df::modules::solidity::profile::mod()`
 - `p6df::modules::solidity::vscodes()`
+- `words solidity = p6df::modules::solidity::profile::mod()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -85,10 +85,10 @@ p6df::modules::solidity::clones() {
 ######################################################################
 #<
 #
-# Function: words solidity $SOLC_VERSION = p6df::modules::solidity::profile::mod()
+# Function: words solidity = p6df::modules::solidity::profile::mod()
 #
 #  Returns:
-#	words - solidity $SOLC_VERSION
+#	words - solidity
 #
 #  Environment:	 SOLC_VERSION
 #>


### PR DESCRIPTION
**What:** Rename `external::brew` to `external::brews` and fix profile::mod return type annotation

**Why:** Normalizes function naming convention (plural `brews`) and uses consistent `words solidity` return type (removing `$SOLC_VERSION` from the type annotation)

**Test plan:** Shell loads without errors; solidity profile::mod returns expected value

**Dependencies:** none